### PR TITLE
Reset state in order to be able to continue uploading

### DIFF
--- a/src/DirectUploadProvider.js
+++ b/src/DirectUploadProvider.js
@@ -100,6 +100,7 @@ class DirectUploadProvider extends React.Component<Props, State> {
     [string]: ActiveStorageFileUpload,
   }) =>
     this.setState(({ fileUploads }) => ({
+      uploading: false,
       fileUploads: { ...fileUploads, ...fileUpload },
     }))
 

--- a/src/DirectUploadProvider.test.js
+++ b/src/DirectUploadProvider.test.js
@@ -109,4 +109,15 @@ describe('DirectUploadProvider', () => {
     await tree.props.handleUpload([file])
     expect(onSuccess).toHaveBeenCalledWith(['signedId'])
   })
+
+  it('is ready for another upload when an error happens', async () => {
+    fetch.mockRejectedValue(new Error('Fetch error'))
+
+    await tree.props.handleUpload([file])
+    expect(component.getInstance().state.uploading).toBe(false)
+
+    // Try to upload again
+    await tree.props.handleUpload([file])
+    expect(component.getInstance().state.uploading).toBe(false)
+  })
 })


### PR DESCRIPTION
This PR aims to fix the issue where after a network failure the ready keeps in the uploading state instead of preventing the user from continuing to upload.

[Open Issue from the forked repository](https://github.com/cbothner/react-activestorage-provider/issues/48)