### PR TITLE
Fix usage of Promise.all

### DIFF
--- a/src/DirectUploadProvider.js
+++ b/src/DirectUploadProvider.js
@@ -87,9 +87,13 @@ class DirectUploadProvider extends React.Component<Props, State> {
 
     this.setState({ uploading: true })
 
-    const signedIds = await Promise.all(
+    const response = await Promise.allSettled(
       this.uploads.map(upload => upload.start())
     )
+
+    const signedIds = (response || [])
+      .filter(({ status }) => status === 'fulfilled')
+      .map(({ value }) => value)
 
     this.props.onSuccess(signedIds)
     this.uploads = []


### PR DESCRIPTION
This PR change the usage of `Promise.all` by `Promise.allSettled` - [Check out these docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#promise_concurrency) for more information on them both.

By using `Promise.allSettled` we're not rejecting all uploads when one of them is rejected as it's happening with `Promise.all`